### PR TITLE
Compile all examples in CI and fix compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            project: [Demo-ADC-Buzzer, Demo-RVMON, Demo-Tetris, Demo-Towers-Interactive, Demo-Towers, Demo-VGA, PlatformIO/RVPC]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Install CH32V Platform
+        run: pio pkg install -g -p "https://github.com/Community-PIO-CH32V/platform-ch32v.git"
+
+      - name: Build Project
+        run: cd SOFTWARE && cd ${{ matrix.project }} && pio run

--- a/SOFTWARE/Demo-ADC-Buzzer/src/main.c
+++ b/SOFTWARE/Demo-ADC-Buzzer/src/main.c
@@ -135,7 +135,7 @@ void calcDelay(uint32_t *delay) {
 }
 
 int main(void) {
-	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
+	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
 	SystemCoreClockUpdate();
 
 	// Disable GPIO Alternate Functions

--- a/SOFTWARE/PlatformIO/RVPC/src/main.c
+++ b/SOFTWARE/PlatformIO/RVPC/src/main.c
@@ -7,7 +7,7 @@ void HardFault_Handler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 #define BUZZER_DELAY_MS 1
 
 int main(void) {
-	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
+	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
 	SystemCoreClockUpdate();
     
     Delay_Init();


### PR DESCRIPTION
Uses free Github Actions CI to build all projects inside `SOFTWARE` ([docs](https://docs.platformio.org/en/latest/integration/ci/github-actions.html)).

Fixes compilation for the  ADC buzzer and RVPC project by replacing `NVIC_PriorityGroup_2` with `NVIC_PriorityGroup_1`. The WCH people deleted that from the SDK (change introduced in [SDK version 1.7](https://github.com/openwch/ch32v003/commit/450305c82942de8943e74bcd4fd7ec12916970c0#diff-1de1db839c49602760764d5e8462477202c632d1f70a63545e06cebd2488f4c5)). Priority group 1 is then what's used in the current official examples:

https://github.com/openwch/ch32v003/blob/f9fd9c896feed53f29350e099e4a0cd9a8bdecca/EVT/EXAM/GPIO/GPIO_Toggle/User/main.c#L54

Gives the project the green checkmark in the commit line for passing CI.